### PR TITLE
[Refactoring] extract token related contracts method to tokenManager

### DIFF
--- a/packages/plasma-light-client/__tests__/TokenManager.test.ts
+++ b/packages/plasma-light-client/__tests__/TokenManager.test.ts
@@ -1,6 +1,9 @@
 import TokenManager from '../src/managers/TokenManager'
 import { Integer, Address } from '@cryptoeconomicslab/primitives'
-import { IERC20DetailedContract } from '@cryptoeconomicslab/contract'
+import {
+  IERC20DetailedContract,
+  IDepositContract
+} from '@cryptoeconomicslab/contract'
 
 const mockApprove = jest.fn()
 const mockDecimals = jest.fn().mockImplementation(() => Integer.from(6))
@@ -11,6 +14,10 @@ const MockERC20Contract = jest.fn().mockImplementation((address: Address) => {
     address
   }
 }) as jest.Mock<IERC20DetailedContract>
+
+const MockDepositContract = jest.fn().mockImplementation((address: Address) => {
+  return { address }
+}) as jest.Mock<IDepositContract>
 
 describe('TokenManager', () => {
   let tokenManager: TokenManager
@@ -26,6 +33,31 @@ describe('TokenManager', () => {
     tokenManager = new TokenManager()
   })
 
+  test('get depositContractAddresses', () => {
+    tokenManager.addDepositContract(
+      depositContractAddress,
+      new MockDepositContract(depositContractAddress)
+    )
+    expect(tokenManager.depositContractAddresses).toEqual([
+      depositContractAddress
+    ])
+  })
+
+  test('add token', async () => {
+    await tokenManager.addContracts(
+      new MockERC20Contract(tokenAddress),
+      new MockDepositContract(depositContractAddress)
+    )
+    const tokenContract = tokenManager.getTokenContract(depositContractAddress)
+    expect(tokenContract).not.toBeUndefined()
+    expect(tokenContract?.address).toEqual(tokenAddress)
+    const depositContract = tokenManager.getDepositContract(
+      depositContractAddress
+    )
+    expect(depositContract).not.toBeUndefined()
+    expect(depositContract?.address).toEqual(depositContractAddress)
+  })
+
   test('addTokenContract and getTokenContract', async () => {
     await tokenManager.addTokenContract(
       depositContractAddress,
@@ -34,6 +66,18 @@ describe('TokenManager', () => {
     const tokenContract = tokenManager.getTokenContract(depositContractAddress)
     expect(tokenContract).not.toBeUndefined()
     expect(tokenContract?.address).toEqual(tokenAddress)
+  })
+
+  test('addDepositContract and getDepositContract', () => {
+    tokenManager.addDepositContract(
+      depositContractAddress,
+      new MockDepositContract(depositContractAddress)
+    )
+    const depositContract = tokenManager.getDepositContract(
+      depositContractAddress
+    )
+    expect(depositContract).not.toBeUndefined()
+    expect(depositContract?.address).toEqual(depositContractAddress)
   })
 
   test('addTokenContract and getDecimals', async () => {

--- a/packages/plasma-light-client/src/managers/TokenManager.ts
+++ b/packages/plasma-light-client/src/managers/TokenManager.ts
@@ -1,15 +1,63 @@
-import { IERC20DetailedContract } from '@cryptoeconomicslab/contract'
+import {
+  IERC20DetailedContract,
+  IDepositContract
+} from '@cryptoeconomicslab/contract'
 import { Integer, Address } from '@cryptoeconomicslab/primitives'
 
 /**
- * @description TokenManager manages token information
+ * @description TokenManager manages token contracts and deposit contracts
  */
 export default class TokenManager {
+  private depositContractAddressStrings: Set<string> = new Set()
+  private depositContracts: Map<string, IDepositContract> = new Map()
   private tokenContracts: Map<string, IERC20DetailedContract> = new Map()
   private tokenDecimals: Map<string, Integer> = new Map()
 
+  get depositContractAddresses(): Address[] {
+    return Array.from(this.depositContractAddressStrings).map(addr =>
+      Address.from(addr)
+    )
+  }
+
   /**
-   * Add Token Contract by Deposit Contract address.
+   * add pair of ERC20 contract and Deposit contract to be managed
+   * @param erc20Contract ERC20 contract to add
+   * @param depositContract Deposit contract to add
+   */
+  async addContracts(
+    erc20Contract: IERC20DetailedContract,
+    depositContract: IDepositContract
+  ) {
+    const depositContractAddress = depositContract.address
+    this.addDepositContract(depositContractAddress, depositContract)
+    await this.addTokenContract(depositContractAddress, erc20Contract)
+  }
+
+  /**
+   * Add Deposit Contract with key of Deposit Contract's address.
+   * @param depositContractAddress address of deposit contract
+   * @param depositContract Instance of DepositContract
+   */
+  addDepositContract(
+    depositContractAddress: Address,
+    depositContract: IDepositContract
+  ) {
+    this.depositContracts.set(depositContractAddress.data, depositContract)
+    this.depositContractAddressStrings.add(depositContractAddress.data)
+  }
+
+  /**
+   * get deposit contract by address
+   * @param depositContractAddress address of deposit contract
+   */
+  getDepositContract(
+    depositContractAddress: Address
+  ): IDepositContract | undefined {
+    return this.depositContracts.get(depositContractAddress.data)
+  }
+
+  /**
+   * Add Token Contract with key of Deposit Contract's address.
    * @param depositContractAddress The address of Deposit Contract
    * @param erc20Contract Instance of ERC20Contract
    */


### PR DESCRIPTION
in order to make clear sense of tokenManager and make LightClient thinner.

- move getDepositContract to tokenManager
- move getERC20Contract to tokenManager
- move depositContractsMap to tokenManager