### PR TITLE
add approval option at EventWatcher

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4291,7 +4291,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4312,12 +4313,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4332,17 +4335,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4459,7 +4465,8 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4471,6 +4478,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4485,6 +4493,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4492,12 +4501,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4516,6 +4527,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4605,7 +4617,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4617,6 +4630,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4702,7 +4716,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4738,6 +4753,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4757,6 +4773,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4800,12 +4817,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/packages/eth-contract/__test__/EthEventWatcher.test.ts
+++ b/packages/eth-contract/__test__/EthEventWatcher.test.ts
@@ -1,0 +1,55 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-empty-function */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import EventWatcher from '../src/events/EthEventWatcher'
+import { EventDb } from '@cryptoeconomicslab/contract'
+import { mocked } from 'ts-jest/utils'
+jest.mock('@cryptoeconomicslab/contract')
+const undefindMock = jest.fn().mockResolvedValue(undefined)
+let specifiedToBlock = 0
+const funcGetLogs = async function(param: any): Promise<[]> {
+  specifiedToBlock = param.toBlock
+  return []
+}
+mocked(EventDb).mockImplementation((): any => {
+  return {
+    setLastLoggedBlock: undefindMock
+  }
+})
+describe('EventWatcher', () => {
+  describe('poll', () => {
+    test('When the approval option is specified, the toBlock option is set to the current block number minus the value of approval.', async () => {
+      const eventWatcher = new EventWatcher({
+        provider: {
+          getLogs: funcGetLogs
+        } as any,
+        kvs: {} as any,
+        contractAddress: {} as any,
+        contractInterface: this.connection.interface,
+        options: {
+          interval: 0,
+          approval: 3
+        }
+      })
+      specifiedToBlock = 0
+      await eventWatcher.poll(0, 5, () => {})
+      expect(specifiedToBlock).toBe(2)
+    })
+    test('When the approval option is not specified, the toBlock option is set to the current block number', async () => {
+      const eventWatcher = new EventWatcher({
+        provider: {
+          getLogs: funcGetLogs
+        } as any,
+        kvs: {} as any,
+        contractAddress: {} as any,
+        contractInterface: this.connection.interface,
+        options: {
+          interval: 0
+        }
+      })
+      specifiedToBlock = 0
+      await eventWatcher.poll(0, 5, () => {})
+      expect(specifiedToBlock).toBe(5)
+    })
+  })
+})

--- a/packages/eth-contract/__tests__/EthEventWatcher.test.ts
+++ b/packages/eth-contract/__tests__/EthEventWatcher.test.ts
@@ -4,16 +4,24 @@
 import EventWatcher from '../src/events/EthEventWatcher'
 import { EventDb } from '@cryptoeconomicslab/contract'
 import { mocked } from 'ts-jest/utils'
+import { Bytes } from '@cryptoeconomicslab/primitives'
 jest.mock('@cryptoeconomicslab/contract')
 const undefindMock = jest.fn().mockResolvedValue(undefined)
 let specifiedToBlock = 0
+let specifiedLoggedToBlock = 0
 const funcGetLogs = async function(param: any): Promise<[]> {
   specifiedToBlock = param.toBlock
   return []
 }
+const funcSetLastLoggedBlock = async function(
+  _: Bytes,
+  blockNumber: number
+): Promise<void> {
+  specifiedLoggedToBlock = blockNumber
+}
 mocked(EventDb).mockImplementation((): any => {
   return {
-    setLastLoggedBlock: undefindMock
+    setLastLoggedBlock: funcSetLastLoggedBlock
   }
 })
 describe('EventWatcher', () => {
@@ -25,15 +33,17 @@ describe('EventWatcher', () => {
         } as any,
         kvs: {} as any,
         contractAddress: {} as any,
-        contractInterface: this.connection.interface,
+        contractInterface: {} as any,
         options: {
           interval: 0,
           approval: 3
         }
       })
       specifiedToBlock = 0
+      specifiedLoggedToBlock = 0
       await eventWatcher.poll(0, 5, () => {})
       expect(specifiedToBlock).toBe(2)
+      expect(specifiedLoggedToBlock).toBe(2)
     })
     test('When the approval option is not specified, the toBlock option is set to the current block number', async () => {
       const eventWatcher = new EventWatcher({
@@ -42,14 +52,16 @@ describe('EventWatcher', () => {
         } as any,
         kvs: {} as any,
         contractAddress: {} as any,
-        contractInterface: this.connection.interface,
+        contractInterface: {} as any,
         options: {
           interval: 0
         }
       })
       specifiedToBlock = 0
+      specifiedLoggedToBlock = 0
       await eventWatcher.poll(0, 5, () => {})
       expect(specifiedToBlock).toBe(5)
+      expect(specifiedLoggedToBlock).toBe(5)
     })
   })
 })

--- a/packages/eth-contract/src/events/EthEventWatcher.ts
+++ b/packages/eth-contract/src/events/EthEventWatcher.ts
@@ -75,9 +75,7 @@ export default class EventWatcher implements IEventWatcher {
       const loaded = await this.eventDb.getLastLoggedBlock(
         Bytes.fromString(this.contractAddress)
       )
-      const approval =
-        typeof this.options.approval === 'undefined' ? 0 : this.options.approval
-      await this.poll(loaded + 1, block.number - approval, handler)
+      await this.poll(loaded + 1, block.number, handler)
     } catch (e) {
       console.log(e)
       if (errorHandler) {
@@ -102,10 +100,12 @@ export default class EventWatcher implements IEventWatcher {
     blockNumber: number,
     completedHandler: CompletedHandler
   ) {
+    const approval =
+      typeof this.options.approval === 'undefined' ? 0 : this.options.approval
     const events = await this.httpProvider.getLogs({
       address: this.contractAddress,
       fromBlock: fromBlockNumber,
-      toBlock: blockNumber
+      toBlock: blockNumber - approval
     })
     for (const event of events) {
       if (event.transactionHash && event.logIndex !== undefined) {
@@ -135,7 +135,7 @@ export default class EventWatcher implements IEventWatcher {
     }
     await this.eventDb.setLastLoggedBlock(
       Bytes.fromString(this.contractAddress),
-      blockNumber
+      blockNumber - approval
     )
     completedHandler()
   }

--- a/packages/eth-contract/src/events/EthEventWatcher.ts
+++ b/packages/eth-contract/src/events/EthEventWatcher.ts
@@ -13,6 +13,7 @@ type Provider = ethers.providers.Provider
 
 export interface EventWatcherOptions {
   interval?: number
+  approval?: number
 }
 
 export type EthEventWatcherArgType = {
@@ -74,7 +75,9 @@ export default class EventWatcher implements IEventWatcher {
       const loaded = await this.eventDb.getLastLoggedBlock(
         Bytes.fromString(this.contractAddress)
       )
-      await this.poll(loaded + 1, block.number, handler)
+      const approval =
+        typeof this.options.approval === 'undefined' ? 0 : this.options.approval
+      await this.poll(loaded + 1, block.number - approval, handler)
     } catch (e) {
       console.log(e)
       if (errorHandler) {

--- a/packages/eth-contract/src/events/EthEventWatcher.ts
+++ b/packages/eth-contract/src/events/EthEventWatcher.ts
@@ -100,8 +100,7 @@ export default class EventWatcher implements IEventWatcher {
     blockNumber: number,
     completedHandler: CompletedHandler
   ) {
-    const approval =
-      typeof this.options.approval === 'undefined' ? 0 : this.options.approval
+    const approval = !this.options.approval ? 0 : this.options.approval
     const events = await this.httpProvider.getLogs({
       address: this.contractAddress,
       fromBlock: fromBlockNumber,


### PR DESCRIPTION
# description

add approval option at EventWatcher

# why

can exclude events in blocks that don't meet the number of approvals.