### PR TITLE
sync block timestamp with commitment transaction mined on L1

### DIFF
--- a/integration-test/e2e-tests/__tests__/index.test.ts
+++ b/integration-test/e2e-tests/__tests__/index.test.ts
@@ -3,6 +3,7 @@ import {
   Address,
   Bytes,
   BigNumber,
+  Integer,
   Range
 } from '@cryptoeconomicslab/primitives'
 import { LevelKeyValueStore } from '@cryptoeconomicslab/level-kvs'
@@ -168,7 +169,12 @@ describe('light client', () => {
     const stateUpdatesMap = new Map()
     stateUpdatesMap.set(config.PlasmaETH, stateUpdates)
     const timestamp = DateUtils.getCurrentDate()
-    return new Block(blockNumber, stateUpdatesMap, timestamp)
+    return new Block(
+      blockNumber,
+      stateUpdatesMap,
+      BigNumber.from(0),
+      Integer.from(timestamp)
+    )
   }
 
   async function exitInvalidStateUpdate(

--- a/packages/contract/src/contract/interfaces/ICommitmentContract.ts
+++ b/packages/contract/src/contract/interfaces/ICommitmentContract.ts
@@ -1,4 +1,4 @@
-import { FixedBytes, BigNumber } from '@cryptoeconomicslab/primitives'
+import { FixedBytes, BigNumber, Integer } from '@cryptoeconomicslab/primitives'
 
 export interface ICommitmentContract {
   submit(blockNumber: BigNumber, root: FixedBytes): Promise<void>
@@ -8,7 +8,12 @@ export interface ICommitmentContract {
   getRoot(blockNumber: BigNumber): Promise<FixedBytes>
 
   subscribeBlockSubmitted(
-    handler: (blockNumber: BigNumber, root: FixedBytes) => Promise<void>
+    handler: (
+      blockNumber: BigNumber,
+      root: FixedBytes,
+      mainchainBlockNumber: BigNumber,
+      mainchainTimestamp: Integer
+    ) => Promise<void>
   ): void
 
   startWatchingEvents(): void

--- a/packages/contract/src/events/types/EventLog.ts
+++ b/packages/contract/src/events/types/EventLog.ts
@@ -1,4 +1,7 @@
+import { BigNumber } from '@cryptoeconomicslab/primitives'
+
 export default interface EventLog {
+  mainchainBlockNumber: BigNumber
   name: string
   values: any
 }

--- a/packages/eth-contract/src/contract/CommitmentContract.ts
+++ b/packages/eth-contract/src/contract/CommitmentContract.ts
@@ -70,14 +70,14 @@ export class CommitmentContract implements ICommitmentContract {
     this.eventWatcher.subscribe('BlockSubmitted', async (log: EventLog) => {
       const blockNumber = log.values.blockNumber
       const root = log.values.root
-      const mainchainBlockNumber = log.values.mainchainBlockNumber
+      const mainchainBlockNumber = log.mainchainBlockNumber
       const timestamp = (
         await this.connection.provider.getBlock(mainchainBlockNumber.raw)
       ).timestamp
       await handler(
         BigNumber.fromString(blockNumber.toString()),
         FixedBytes.fromHexString(32, root),
-        BigNumber.from(mainchainBlockNumber.toString()),
+        mainchainBlockNumber,
         Integer.from(timestamp)
       )
     })

--- a/packages/eth-contract/src/contract/CommitmentContract.ts
+++ b/packages/eth-contract/src/contract/CommitmentContract.ts
@@ -72,7 +72,7 @@ export class CommitmentContract implements ICommitmentContract {
       const root = log.values.root
       const mainchainBlockNumber = log.values.mainchainBlockNumber
       const timestamp = (
-        await this.connection.provider.getBlock(mainchainBlockNumber.toString())
+        await this.connection.provider.getBlock(mainchainBlockNumber.raw)
       ).timestamp
       await handler(
         BigNumber.fromString(blockNumber.toString()),

--- a/packages/eth-contract/src/contract/CommitmentContract.ts
+++ b/packages/eth-contract/src/contract/CommitmentContract.ts
@@ -72,7 +72,9 @@ export class CommitmentContract implements ICommitmentContract {
       const root = log.values.root
       const mainchainBlockNumber = log.mainchainBlockNumber
       const timestamp = (
-        await this.connection.provider.getBlock(mainchainBlockNumber.raw)
+        await this.connection.provider.getBlock(
+          Number(mainchainBlockNumber.raw)
+        )
       ).timestamp
       await handler(
         BigNumber.fromString(blockNumber.toString()),

--- a/packages/eth-contract/src/events/EthEventWatcher.ts
+++ b/packages/eth-contract/src/events/EthEventWatcher.ts
@@ -1,5 +1,5 @@
 import * as ethers from 'ethers'
-import { Bytes } from '@cryptoeconomicslab/primitives'
+import { BigNumber, Bytes } from '@cryptoeconomicslab/primitives'
 import { KeyValueStore } from '@cryptoeconomicslab/db'
 import {
   EventDb,
@@ -126,10 +126,9 @@ export default class EventWatcher implements IEventWatcher {
       const handler = this.checkingEvents.get(logDesc.name)
       if (handler) {
         const eventLog: EventLog = {
+          mainchainBlockNumber: BigNumber.from(event.blockNumber),
           name: logDesc.name,
-          values: Object.assign({}, logDesc.values, {
-            mainchainBlockNumber: event.blockNumber
-          })
+          values: logDesc.values
         }
         await handler(eventLog)
         if (event.transactionHash && event.logIndex !== undefined) {

--- a/packages/eth-contract/src/events/EthEventWatcher.ts
+++ b/packages/eth-contract/src/events/EthEventWatcher.ts
@@ -1,14 +1,14 @@
 import * as ethers from 'ethers'
-import { BigNumber, Bytes } from '@cryptoeconomicslab/primitives'
+import { Bytes } from '@cryptoeconomicslab/primitives'
 import { KeyValueStore } from '@cryptoeconomicslab/db'
 import {
   EventDb,
   EventHandler,
   ErrorHandler,
+  EventLog,
   IEventWatcher,
   CompletedHandler
 } from '@cryptoeconomicslab/contract'
-import { Log } from 'ethers/providers'
 type Provider = ethers.providers.Provider
 
 export interface EventWatcherOptions {
@@ -125,8 +125,13 @@ export default class EventWatcher implements IEventWatcher {
 
       const handler = this.checkingEvents.get(logDesc.name)
       if (handler) {
-        logDesc.values.mainchainBlockNumber = BigNumber.from(event.blockNumber)
-        await handler(logDesc)
+        const eventLog: EventLog = {
+          name: logDesc.name,
+          values: Object.assign({}, logDesc.values, {
+            mainchainBlockNumber: event.blockNumber
+          })
+        }
+        await handler(eventLog)
         if (event.transactionHash && event.logIndex !== undefined) {
           await this.eventDb.addSeen(
             this.getEventId(event.transactionHash, event.logIndex)

--- a/packages/eth-contract/src/events/EthEventWatcher.ts
+++ b/packages/eth-contract/src/events/EthEventWatcher.ts
@@ -1,5 +1,5 @@
 import * as ethers from 'ethers'
-import { Bytes } from '@cryptoeconomicslab/primitives'
+import { BigNumber, Bytes } from '@cryptoeconomicslab/primitives'
 import { KeyValueStore } from '@cryptoeconomicslab/db'
 import {
   EventDb,
@@ -105,6 +105,9 @@ export default class EventWatcher implements IEventWatcher {
       toBlock: blockNumber
     })
     for (const event of events) {
+      if (!event.blockNumber) {
+        continue
+      }
       if (event.transactionHash && event.logIndex !== undefined) {
         const seen = await this.eventDb.getSeen(
           this.getEventId(event.transactionHash, event.logIndex)
@@ -122,6 +125,7 @@ export default class EventWatcher implements IEventWatcher {
 
       const handler = this.checkingEvents.get(logDesc.name)
       if (handler) {
+        logDesc.values.mainchainBlockNumber = BigNumber.from(event.blockNumber)
         await handler(logDesc)
         if (event.transactionHash && event.logIndex !== undefined) {
           await this.eventDb.addSeen(

--- a/packages/plasma-aggregator/__tests__/BlockExplorer/Types/BlockItem.test.ts
+++ b/packages/plasma-aggregator/__tests__/BlockExplorer/Types/BlockItem.test.ts
@@ -4,6 +4,7 @@ import {
   Address,
   Bytes,
   BigNumber,
+  Integer,
   Range
 } from '@cryptoeconomicslab/primitives'
 import { Property } from '@cryptoeconomicslab/ovm'
@@ -31,12 +32,18 @@ describe('BlockItem', () => {
   map.set(testAddr, [su, su])
   map.set(testAddr2, [su, su, su])
   const timestamp = DateUtils.getCurrentDate()
-  const block = new Block(BigNumber.from(5), map, timestamp)
+  const block = new Block(
+    BigNumber.from(5),
+    map,
+    BigNumber.from(10),
+    Integer.from(timestamp)
+  )
 
   test('transformBlockItemFrom', () => {
     expect(transformBlockItemFrom(block)).toEqual({
       blockNumber: '5',
       transactions: 5,
+      mainchainBlockNumber: '10',
       timestamp
     })
   })

--- a/packages/plasma-aggregator/__tests__/BlockExplorer/controller.test.ts
+++ b/packages/plasma-aggregator/__tests__/BlockExplorer/controller.test.ts
@@ -4,6 +4,7 @@ import {
   Address,
   Bytes,
   BigNumber,
+  Integer,
   Range
 } from '@cryptoeconomicslab/primitives'
 import { Property } from '@cryptoeconomicslab/ovm'
@@ -31,7 +32,12 @@ const TIME_STAMP = DateUtils.getCurrentDate()
 const block = (bn: number, addr: string, sus: StateUpdate[]) => {
   const map = new Map()
   map.set(addr, sus)
-  return new Block(BigNumber.from(bn), map, TIME_STAMP)
+  return new Block(
+    BigNumber.from(bn),
+    map,
+    BigNumber.from(0),
+    Integer.from(TIME_STAMP)
+  )
 }
 
 describe('BlockExplorerController', () => {
@@ -60,6 +66,7 @@ describe('BlockExplorerController', () => {
       expect(b).toEqual({
         blockNumber: '1',
         transactions: 3,
+        mainchainBlockNumber: '0',
         timestamp: TIME_STAMP
       })
     })
@@ -83,16 +90,66 @@ describe('BlockExplorerController', () => {
       const controller = new BlockExplorerController(blockManager, stateManager)
       const blocks = await controller.handleBlockList()
       expect(blocks).toEqual([
-        { blockNumber: '3', transactions: 1, timestamp: TIME_STAMP },
-        { blockNumber: '4', transactions: 1, timestamp: TIME_STAMP },
-        { blockNumber: '5', transactions: 1, timestamp: TIME_STAMP },
-        { blockNumber: '6', transactions: 1, timestamp: TIME_STAMP },
-        { blockNumber: '7', transactions: 1, timestamp: TIME_STAMP },
-        { blockNumber: '8', transactions: 1, timestamp: TIME_STAMP },
-        { blockNumber: '9', transactions: 1, timestamp: TIME_STAMP },
-        { blockNumber: '10', transactions: 1, timestamp: TIME_STAMP },
-        { blockNumber: '11', transactions: 1, timestamp: TIME_STAMP },
-        { blockNumber: '12', transactions: 1, timestamp: TIME_STAMP }
+        {
+          blockNumber: '3',
+          transactions: 1,
+          mainchainBlockNumber: '0',
+          timestamp: TIME_STAMP
+        },
+        {
+          blockNumber: '4',
+          transactions: 1,
+          mainchainBlockNumber: '0',
+          timestamp: TIME_STAMP
+        },
+        {
+          blockNumber: '5',
+          transactions: 1,
+          mainchainBlockNumber: '0',
+          timestamp: TIME_STAMP
+        },
+        {
+          blockNumber: '6',
+          transactions: 1,
+          mainchainBlockNumber: '0',
+          timestamp: TIME_STAMP
+        },
+        {
+          blockNumber: '7',
+          transactions: 1,
+          mainchainBlockNumber: '0',
+          timestamp: TIME_STAMP
+        },
+        {
+          blockNumber: '8',
+          transactions: 1,
+          mainchainBlockNumber: '0',
+          timestamp: TIME_STAMP
+        },
+        {
+          blockNumber: '9',
+          transactions: 1,
+          mainchainBlockNumber: '0',
+          timestamp: TIME_STAMP
+        },
+        {
+          blockNumber: '10',
+          transactions: 1,
+          mainchainBlockNumber: '0',
+          timestamp: TIME_STAMP
+        },
+        {
+          blockNumber: '11',
+          transactions: 1,
+          mainchainBlockNumber: '0',
+          timestamp: TIME_STAMP
+        },
+        {
+          blockNumber: '12',
+          transactions: 1,
+          mainchainBlockNumber: '0',
+          timestamp: TIME_STAMP
+        }
       ])
     })
 
@@ -103,9 +160,24 @@ describe('BlockExplorerController', () => {
         to: BigNumber.from(9)
       })
       expect(blocks).toEqual([
-        { blockNumber: '7', transactions: 1, timestamp: TIME_STAMP },
-        { blockNumber: '8', transactions: 1, timestamp: TIME_STAMP },
-        { blockNumber: '9', transactions: 1, timestamp: TIME_STAMP }
+        {
+          blockNumber: '7',
+          transactions: 1,
+          mainchainBlockNumber: '0',
+          timestamp: TIME_STAMP
+        },
+        {
+          blockNumber: '8',
+          transactions: 1,
+          mainchainBlockNumber: '0',
+          timestamp: TIME_STAMP
+        },
+        {
+          blockNumber: '9',
+          transactions: 1,
+          mainchainBlockNumber: '0',
+          timestamp: TIME_STAMP
+        }
       ])
     })
 
@@ -115,12 +187,42 @@ describe('BlockExplorerController', () => {
         from: BigNumber.from(7)
       })
       expect(blocks).toEqual([
-        { blockNumber: '7', transactions: 1, timestamp: TIME_STAMP },
-        { blockNumber: '8', transactions: 1, timestamp: TIME_STAMP },
-        { blockNumber: '9', transactions: 1, timestamp: TIME_STAMP },
-        { blockNumber: '10', transactions: 1, timestamp: TIME_STAMP },
-        { blockNumber: '11', transactions: 1, timestamp: TIME_STAMP },
-        { blockNumber: '12', transactions: 1, timestamp: TIME_STAMP }
+        {
+          blockNumber: '7',
+          transactions: 1,
+          mainchainBlockNumber: '0',
+          timestamp: TIME_STAMP
+        },
+        {
+          blockNumber: '8',
+          transactions: 1,
+          mainchainBlockNumber: '0',
+          timestamp: TIME_STAMP
+        },
+        {
+          blockNumber: '9',
+          transactions: 1,
+          mainchainBlockNumber: '0',
+          timestamp: TIME_STAMP
+        },
+        {
+          blockNumber: '10',
+          transactions: 1,
+          mainchainBlockNumber: '0',
+          timestamp: TIME_STAMP
+        },
+        {
+          blockNumber: '11',
+          transactions: 1,
+          mainchainBlockNumber: '0',
+          timestamp: TIME_STAMP
+        },
+        {
+          blockNumber: '12',
+          transactions: 1,
+          mainchainBlockNumber: '0',
+          timestamp: TIME_STAMP
+        }
       ])
     })
 
@@ -130,16 +232,66 @@ describe('BlockExplorerController', () => {
         to: BigNumber.from(11)
       })
       expect(blocks).toEqual([
-        { blockNumber: '2', transactions: 1, timestamp: TIME_STAMP },
-        { blockNumber: '3', transactions: 1, timestamp: TIME_STAMP },
-        { blockNumber: '4', transactions: 1, timestamp: TIME_STAMP },
-        { blockNumber: '5', transactions: 1, timestamp: TIME_STAMP },
-        { blockNumber: '6', transactions: 1, timestamp: TIME_STAMP },
-        { blockNumber: '7', transactions: 1, timestamp: TIME_STAMP },
-        { blockNumber: '8', transactions: 1, timestamp: TIME_STAMP },
-        { blockNumber: '9', transactions: 1, timestamp: TIME_STAMP },
-        { blockNumber: '10', transactions: 1, timestamp: TIME_STAMP },
-        { blockNumber: '11', transactions: 1, timestamp: TIME_STAMP }
+        {
+          blockNumber: '2',
+          transactions: 1,
+          mainchainBlockNumber: '0',
+          timestamp: TIME_STAMP
+        },
+        {
+          blockNumber: '3',
+          transactions: 1,
+          mainchainBlockNumber: '0',
+          timestamp: TIME_STAMP
+        },
+        {
+          blockNumber: '4',
+          transactions: 1,
+          mainchainBlockNumber: '0',
+          timestamp: TIME_STAMP
+        },
+        {
+          blockNumber: '5',
+          transactions: 1,
+          mainchainBlockNumber: '0',
+          timestamp: TIME_STAMP
+        },
+        {
+          blockNumber: '6',
+          transactions: 1,
+          mainchainBlockNumber: '0',
+          timestamp: TIME_STAMP
+        },
+        {
+          blockNumber: '7',
+          transactions: 1,
+          mainchainBlockNumber: '0',
+          timestamp: TIME_STAMP
+        },
+        {
+          blockNumber: '8',
+          transactions: 1,
+          mainchainBlockNumber: '0',
+          timestamp: TIME_STAMP
+        },
+        {
+          blockNumber: '9',
+          transactions: 1,
+          mainchainBlockNumber: '0',
+          timestamp: TIME_STAMP
+        },
+        {
+          blockNumber: '10',
+          transactions: 1,
+          mainchainBlockNumber: '0',
+          timestamp: TIME_STAMP
+        },
+        {
+          blockNumber: '11',
+          transactions: 1,
+          mainchainBlockNumber: '0',
+          timestamp: TIME_STAMP
+        }
       ])
     })
 
@@ -173,6 +325,7 @@ describe('BlockExplorerController', () => {
         stateUpdates.map(su => ({
           hash: su.hash.toHexString(),
           timestamp: TIME_STAMP,
+          mainchainBlockNumber: '0',
           blockNumber: '1',
           depositContractAddress: su.depositContractAddress.data,
           stateObject: {
@@ -215,6 +368,7 @@ describe('BlockExplorerController', () => {
       expect(tx).toEqual({
         hash: s.hash.toHexString(),
         timestamp: TIME_STAMP,
+        mainchainBlockNumber: '0',
         blockNumber: '1',
         depositContractAddress: s.depositContractAddress.data,
         stateObject: {

--- a/packages/plasma-aggregator/__tests__/BlockExplorer/controller.test.ts
+++ b/packages/plasma-aggregator/__tests__/BlockExplorer/controller.test.ts
@@ -35,7 +35,7 @@ const block = (bn: number, addr: string, sus: StateUpdate[]) => {
   return new Block(
     BigNumber.from(bn),
     map,
-    BigNumber.from(0),
+    BigNumber.from(10),
     Integer.from(TIME_STAMP)
   )
 }
@@ -66,7 +66,7 @@ describe('BlockExplorerController', () => {
       expect(b).toEqual({
         blockNumber: '1',
         transactions: 3,
-        mainchainBlockNumber: '0',
+        mainchainBlockNumber: '10',
         timestamp: TIME_STAMP
       })
     })
@@ -93,61 +93,61 @@ describe('BlockExplorerController', () => {
         {
           blockNumber: '3',
           transactions: 1,
-          mainchainBlockNumber: '0',
+          mainchainBlockNumber: '10',
           timestamp: TIME_STAMP
         },
         {
           blockNumber: '4',
           transactions: 1,
-          mainchainBlockNumber: '0',
+          mainchainBlockNumber: '10',
           timestamp: TIME_STAMP
         },
         {
           blockNumber: '5',
           transactions: 1,
-          mainchainBlockNumber: '0',
+          mainchainBlockNumber: '10',
           timestamp: TIME_STAMP
         },
         {
           blockNumber: '6',
           transactions: 1,
-          mainchainBlockNumber: '0',
+          mainchainBlockNumber: '10',
           timestamp: TIME_STAMP
         },
         {
           blockNumber: '7',
           transactions: 1,
-          mainchainBlockNumber: '0',
+          mainchainBlockNumber: '10',
           timestamp: TIME_STAMP
         },
         {
           blockNumber: '8',
           transactions: 1,
-          mainchainBlockNumber: '0',
+          mainchainBlockNumber: '10',
           timestamp: TIME_STAMP
         },
         {
           blockNumber: '9',
           transactions: 1,
-          mainchainBlockNumber: '0',
+          mainchainBlockNumber: '10',
           timestamp: TIME_STAMP
         },
         {
           blockNumber: '10',
           transactions: 1,
-          mainchainBlockNumber: '0',
+          mainchainBlockNumber: '10',
           timestamp: TIME_STAMP
         },
         {
           blockNumber: '11',
           transactions: 1,
-          mainchainBlockNumber: '0',
+          mainchainBlockNumber: '10',
           timestamp: TIME_STAMP
         },
         {
           blockNumber: '12',
           transactions: 1,
-          mainchainBlockNumber: '0',
+          mainchainBlockNumber: '10',
           timestamp: TIME_STAMP
         }
       ])
@@ -163,19 +163,19 @@ describe('BlockExplorerController', () => {
         {
           blockNumber: '7',
           transactions: 1,
-          mainchainBlockNumber: '0',
+          mainchainBlockNumber: '10',
           timestamp: TIME_STAMP
         },
         {
           blockNumber: '8',
           transactions: 1,
-          mainchainBlockNumber: '0',
+          mainchainBlockNumber: '10',
           timestamp: TIME_STAMP
         },
         {
           blockNumber: '9',
           transactions: 1,
-          mainchainBlockNumber: '0',
+          mainchainBlockNumber: '10',
           timestamp: TIME_STAMP
         }
       ])
@@ -190,37 +190,37 @@ describe('BlockExplorerController', () => {
         {
           blockNumber: '7',
           transactions: 1,
-          mainchainBlockNumber: '0',
+          mainchainBlockNumber: '10',
           timestamp: TIME_STAMP
         },
         {
           blockNumber: '8',
           transactions: 1,
-          mainchainBlockNumber: '0',
+          mainchainBlockNumber: '10',
           timestamp: TIME_STAMP
         },
         {
           blockNumber: '9',
           transactions: 1,
-          mainchainBlockNumber: '0',
+          mainchainBlockNumber: '10',
           timestamp: TIME_STAMP
         },
         {
           blockNumber: '10',
           transactions: 1,
-          mainchainBlockNumber: '0',
+          mainchainBlockNumber: '10',
           timestamp: TIME_STAMP
         },
         {
           blockNumber: '11',
           transactions: 1,
-          mainchainBlockNumber: '0',
+          mainchainBlockNumber: '10',
           timestamp: TIME_STAMP
         },
         {
           blockNumber: '12',
           transactions: 1,
-          mainchainBlockNumber: '0',
+          mainchainBlockNumber: '10',
           timestamp: TIME_STAMP
         }
       ])
@@ -235,61 +235,61 @@ describe('BlockExplorerController', () => {
         {
           blockNumber: '2',
           transactions: 1,
-          mainchainBlockNumber: '0',
+          mainchainBlockNumber: '10',
           timestamp: TIME_STAMP
         },
         {
           blockNumber: '3',
           transactions: 1,
-          mainchainBlockNumber: '0',
+          mainchainBlockNumber: '10',
           timestamp: TIME_STAMP
         },
         {
           blockNumber: '4',
           transactions: 1,
-          mainchainBlockNumber: '0',
+          mainchainBlockNumber: '10',
           timestamp: TIME_STAMP
         },
         {
           blockNumber: '5',
           transactions: 1,
-          mainchainBlockNumber: '0',
+          mainchainBlockNumber: '10',
           timestamp: TIME_STAMP
         },
         {
           blockNumber: '6',
           transactions: 1,
-          mainchainBlockNumber: '0',
+          mainchainBlockNumber: '10',
           timestamp: TIME_STAMP
         },
         {
           blockNumber: '7',
           transactions: 1,
-          mainchainBlockNumber: '0',
+          mainchainBlockNumber: '10',
           timestamp: TIME_STAMP
         },
         {
           blockNumber: '8',
           transactions: 1,
-          mainchainBlockNumber: '0',
+          mainchainBlockNumber: '10',
           timestamp: TIME_STAMP
         },
         {
           blockNumber: '9',
           transactions: 1,
-          mainchainBlockNumber: '0',
+          mainchainBlockNumber: '10',
           timestamp: TIME_STAMP
         },
         {
           blockNumber: '10',
           transactions: 1,
-          mainchainBlockNumber: '0',
+          mainchainBlockNumber: '10',
           timestamp: TIME_STAMP
         },
         {
           blockNumber: '11',
           transactions: 1,
-          mainchainBlockNumber: '0',
+          mainchainBlockNumber: '10',
           timestamp: TIME_STAMP
         }
       ])
@@ -325,7 +325,7 @@ describe('BlockExplorerController', () => {
         stateUpdates.map(su => ({
           hash: su.hash.toHexString(),
           timestamp: TIME_STAMP,
-          mainchainBlockNumber: '0',
+          mainchainBlockNumber: '10',
           blockNumber: '1',
           depositContractAddress: su.depositContractAddress.data,
           stateObject: {
@@ -368,7 +368,7 @@ describe('BlockExplorerController', () => {
       expect(tx).toEqual({
         hash: s.hash.toHexString(),
         timestamp: TIME_STAMP,
-        mainchainBlockNumber: '0',
+        mainchainBlockNumber: '10',
         blockNumber: '1',
         depositContractAddress: s.depositContractAddress.data,
         stateObject: {

--- a/packages/plasma-aggregator/__tests__/BlockManager.test.ts
+++ b/packages/plasma-aggregator/__tests__/BlockManager.test.ts
@@ -6,6 +6,7 @@ import {
   Address,
   Bytes,
   BigNumber,
+  Integer,
   Range
 } from '@cryptoeconomicslab/primitives'
 import Coder from '@cryptoeconomicslab/coder'
@@ -48,7 +49,12 @@ describe('BlockManager', () => {
       StateUpdate.fromProperty(stateUpdateProperty)
     ])
     const timestamp = DateUtils.getCurrentDate()
-    const block1 = new Block(BigNumber.from(1), map, timestamp)
+    const block1 = new Block(
+      BigNumber.from(1),
+      map,
+      BigNumber.from(0),
+      Integer.from(timestamp)
+    )
     await blockManager.putBlock(block1)
     const res = await blockManager.getBlock(BigNumber.from(1))
     expect(res).toEqual(block1)
@@ -79,8 +85,12 @@ describe('BlockManager', () => {
     map.set(Address.default().data, [
       StateUpdate.fromProperty(stateUpdateProperty)
     ])
-    const timestamp = DateUtils.getCurrentDate()
-    const expected = new Block(BigNumber.from(1), map, timestamp)
+    const expected = new Block(
+      BigNumber.from(1),
+      map,
+      BigNumber.from(0),
+      Integer.from(0)
+    )
     expect(block).toEqual(expected)
   })
 })

--- a/packages/plasma-aggregator/src/Aggregator.ts
+++ b/packages/plasma-aggregator/src/Aggregator.ts
@@ -97,6 +97,15 @@ export default class Aggregator {
    */
   public run() {
     this.runHttpServer()
+    this.commitmentContract.subscribeBlockSubmitted(
+      async (blockNumber, root, mainchainBlockNumber, mainchainTimestamp) => {
+        this.blockManager.updateBlock(
+          blockNumber,
+          mainchainBlockNumber,
+          mainchainTimestamp
+        )
+      }
+    )
     if (this.option.isSubmitter) {
       this.poll()
     }

--- a/packages/plasma-aggregator/src/Aggregator.ts
+++ b/packages/plasma-aggregator/src/Aggregator.ts
@@ -99,13 +99,14 @@ export default class Aggregator {
     this.runHttpServer()
     this.commitmentContract.subscribeBlockSubmitted(
       async (blockNumber, root, mainchainBlockNumber, mainchainTimestamp) => {
-        this.blockManager.updateBlock(
+        await this.blockManager.updateBlock(
           blockNumber,
           mainchainBlockNumber,
           mainchainTimestamp
         )
       }
     )
+    this.commitmentContract.startWatchingEvents()
     if (this.option.isSubmitter) {
       this.poll()
     }

--- a/packages/plasma-aggregator/src/BlockExplorer/Types/BlockItem.ts
+++ b/packages/plasma-aggregator/src/BlockExplorer/Types/BlockItem.ts
@@ -2,6 +2,7 @@ import { Block } from '@cryptoeconomicslab/plasma'
 
 export interface BlockItem {
   blockNumber: string
+  mainchainBlockNumber: string
   timestamp: number
   transactions: number
 }
@@ -13,7 +14,8 @@ export function transformBlockItemFrom(block: Block): BlockItem {
   )
   return {
     blockNumber: block.blockNumber.raw,
-    timestamp: block.timestamp,
+    mainchainBlockNumber: block.mainchainBlockNumber.raw,
+    timestamp: block.timestamp.data,
     transactions
   }
 }

--- a/packages/plasma-aggregator/src/BlockExplorer/Types/TransactionItem.ts
+++ b/packages/plasma-aggregator/src/BlockExplorer/Types/TransactionItem.ts
@@ -8,8 +8,9 @@ interface StateObject {
 export interface TransactionItem {
   hash: string
   //   from: string
-  timestamp: number
   blockNumber: string
+  mainchainBlockNumber: string
+  timestamp: number
   depositContractAddress: string
   stateObject: StateObject
   range: { start: string; end: string }
@@ -26,8 +27,9 @@ export function transformTransactionItemFrom(
   return {
     hash: su.hash.toHexString(),
     //    from: transaction.from.toString(),
-    timestamp: block.timestamp,
     blockNumber: block.blockNumber.raw,
+    mainchainBlockNumber: block.mainchainBlockNumber.raw,
+    timestamp: block.timestamp.data,
     depositContractAddress: su.depositContractAddress.data,
     range: {
       start: su.range.start.raw,

--- a/packages/plasma-light-client/src/LightClient.ts
+++ b/packages/plasma-light-client/src/LightClient.ts
@@ -273,7 +273,7 @@ export default class LightClient {
    */
   public async start() {
     this.commitmentContract.subscribeBlockSubmitted(
-      async (blockNumber, root) => {
+      async (blockNumber, root, mainchainBlockNumber, mainchainTimestamp) => {
         console.log('new block submitted event:', root.toHexString())
         await this.syncState(blockNumber, root)
         await this.verifyPendingStateUpdates(blockNumber)

--- a/packages/plasma/__tests__/Block.test.ts
+++ b/packages/plasma/__tests__/Block.test.ts
@@ -2,6 +2,7 @@ import {
   Address,
   Bytes,
   BigNumber,
+  Integer,
   Range
 } from '@cryptoeconomicslab/primitives'
 import { Property } from '@cryptoeconomicslab/ovm'
@@ -35,7 +36,12 @@ describe('Block', () => {
       StateUpdate.fromProperty(stateUpdateProperty)
     ])
     const timestamp = DateUtils.getCurrentDate()
-    const block = new Block(BigNumber.from(5), map, timestamp)
+    const block = new Block(
+      BigNumber.from(5),
+      map,
+      BigNumber.from(10),
+      Integer.from(timestamp)
+    )
     const encoded = Coder.encode(block.toStruct())
     const decoded = Block.fromStruct(
       Coder.decode(Block.getParamType(), encoded)
@@ -60,7 +66,12 @@ describe('Block', () => {
     const map = new Map()
     map.set(testAddr.data, [StateUpdate.fromProperty(stateUpdateProperty)])
     const timestamp = DateUtils.getCurrentDate()
-    const block = new Block(BigNumber.from(5), map, timestamp)
+    const block = new Block(
+      BigNumber.from(5),
+      map,
+      BigNumber.from(10),
+      Integer.from(timestamp)
+    )
     const inclusionProof = block.getInclusionProof(
       StateUpdate.fromProperty(stateUpdateProperty)
     )

--- a/packages/plasma/src/types/Block.ts
+++ b/packages/plasma/src/types/Block.ts
@@ -24,8 +24,25 @@ export default class Block {
   constructor(
     readonly blockNumber: BigNumber,
     readonly stateUpdatesMap: Map<string, StateUpdate[]>,
-    readonly timestamp: number
+    private _mainchainBlockNumber: BigNumber = BigNumber.from(0),
+    private _timestamp: Integer = Integer.from(0)
   ) {}
+
+  public get mainchainBlockNumber(): BigNumber {
+    return this._mainchainBlockNumber
+  }
+
+  public get timestamp(): Integer {
+    return this._timestamp
+  }
+
+  public setMainchainBlockNumber(mainchainBlockNumber: BigNumber) {
+    this._mainchainBlockNumber = mainchainBlockNumber
+  }
+
+  public setTimestamp(timestamp: Integer) {
+    this._timestamp = timestamp
+  }
 
   public getTree(): DoubleLayerTree {
     if (this.tree) return this.tree
@@ -104,8 +121,9 @@ export default class Block {
         )
       )
     })
-    const timestamp = s.data[3].value as Integer
-    return new this(blockNumber, map, timestamp.data)
+    const mainchainBlockNumber = s.data[3].value as BigNumber
+    const timestamp = s.data[4].value as Integer
+    return new this(blockNumber, map, mainchainBlockNumber, timestamp)
   }
 
   public toStruct(): Struct {
@@ -147,8 +165,12 @@ export default class Block {
         )
       },
       {
+        key: 'mainchainBlockNumber',
+        value: this.mainchainBlockNumber
+      },
+      {
         key: 'timestamp',
-        value: Integer.from(this.timestamp)
+        value: this.timestamp
       }
     ])
   }
@@ -174,6 +196,10 @@ export default class Block {
           },
           List.from({ default: Property.getParamType }, [])
         )
+      },
+      {
+        key: 'mainchainBlockNumber',
+        value: BigNumber.default()
       },
       {
         key: 'timestamp',


### PR DESCRIPTION
## What?
Sync mainchain block timestamp and block number when subscribing BlockSubmitted.
WAK-379

## Notes
We have to update CommitmentContractWrapper in Substrate and Tezos.
https://github.com/cryptoeconomicslab/gazelle/blob/update/sync-block-timestamp-when-committed/packages/contract/src/contract/interfaces/ICommitmentContract.ts#L10