### PR TITLE
add range getter into UserAction

### DIFF
--- a/packages/plasma-light-client/src/UserAction.ts
+++ b/packages/plasma-light-client/src/UserAction.ts
@@ -150,4 +150,11 @@ export default class UserAction {
   public get blockNumber(): JSBI {
     return this._blockNumber.data
   }
+
+  public get range(): { start: string; end: string } {
+    return {
+      start: this._range.start.raw,
+      end: this._range.end.raw
+    }
+  }
 }


### PR DESCRIPTION
## What?
Add range getter into UserAction.
It will be used to access block explorer from app (like wallet).
WAK-442