### PR TITLE
fix subscribeExitFinalized of light-client

### DIFF
--- a/packages/plasma-light-client/src/LightClient.ts
+++ b/packages/plasma-light-client/src/LightClient.ts
@@ -482,7 +482,7 @@ export default class LightClient {
     this.ee.on(EmitterEvent.TRANSFER_COMPLETE, handler)
   }
 
-  public subscribeExitFinalized(handler: (su: StateUpdate) => void) {
+  public subscribeExitFinalized(handler: (exit: Exit) => void) {
     this.ee.on(EmitterEvent.EXIT_FINALIZED, handler)
   }
 
@@ -500,7 +500,7 @@ export default class LightClient {
     this.ee.off(EmitterEvent.TRANSFER_COMPLETE, handler)
   }
 
-  public unsubscribeExitFinalized(handler: (su: StateUpdate) => void) {
+  public unsubscribeExitFinalized(handler: (exit: Exit) => void) {
     this.ee.off(EmitterEvent.EXIT_FINALIZED, handler)
   }
 }

--- a/packages/plasma-light-client/src/LightClient.ts
+++ b/packages/plasma-light-client/src/LightClient.ts
@@ -482,7 +482,7 @@ export default class LightClient {
     this.ee.on(EmitterEvent.TRANSFER_COMPLETE, handler)
   }
 
-  public subscribeExitFinalized(handler: (exitId: Bytes) => void) {
+  public subscribeExitFinalized(handler: (su: StateUpdate) => void) {
     this.ee.on(EmitterEvent.EXIT_FINALIZED, handler)
   }
 
@@ -500,7 +500,7 @@ export default class LightClient {
     this.ee.off(EmitterEvent.TRANSFER_COMPLETE, handler)
   }
 
-  public unsubscribeExitFinalized(handler: (exitId: Bytes) => void) {
+  public unsubscribeExitFinalized(handler: (su: StateUpdate) => void) {
     this.ee.off(EmitterEvent.EXIT_FINALIZED, handler)
   }
 }

--- a/packages/plasma-light-client/src/usecase/ExitUsecase.ts
+++ b/packages/plasma-light-client/src/usecase/ExitUsecase.ts
@@ -121,7 +121,7 @@ export class ExitUsecase {
       address
     )
 
-    this.ee.emit(EmitterEvent.EXIT_FINALIZED, exit.stateUpdate)
+    this.ee.emit(EmitterEvent.EXIT_FINALIZED, exit)
   }
 
   /**


### PR DESCRIPTION
# What?
fix type of subscribeExitFinalized's handler.
event emit is here.
https://github.com/cryptoeconomicslab/gazelle/blob/master/packages/plasma-light-client/src/usecase/ExitUsecase.ts#L124

## Result of integration test
https://github.com/cryptoeconomicslab/gazelle/runs/976554817?check_suite_focus=true