### PR TITLE
fix syncing root

### DIFF
--- a/packages/plasma-light-client/src/LightClient.ts
+++ b/packages/plasma-light-client/src/LightClient.ts
@@ -235,12 +235,11 @@ export default class LightClient {
           root,
           Address.from(this.address)
         )
-        // await this.pendingStateUpdatesVerifier.verify(blockNumber)
       }
     )
-    this.commitmentContract.startWatchingEvents()
     const blockNumber = await this.commitmentContract.getCurrentBlock()
     await this.stateSyncer.syncLatest(blockNumber, Address.from(this.address))
+    this.commitmentContract.startWatchingEvents()
     this.exitDispute.startWatchingEvents()
   }
 


### PR DESCRIPTION
This PR is for fixing integration-test "multiple transfers in same block".
store Merkle root in SyncRepository before checkpoint verification to avoid throwing error("Merkle root at n is missing.").