### PR TITLE
fix syncLatest

### DIFF
--- a/integration-test/e2e-tests/__tests__/index.test.ts
+++ b/integration-test/e2e-tests/__tests__/index.test.ts
@@ -566,6 +566,23 @@ describe('light client', () => {
     await checkBalance(bobLightClient, '0.1')
     await checkBalance(carolLightClient, '0.3')
 
+    const aliceSyncLightClient = await createClientFromPrivateKey(
+      aliceLightClient['wallet']['ethersWallet'].privateKey
+    )
+    const bobSyncLightClient = await createClientFromPrivateKey(
+      bobLightClient['wallet']['ethersWallet'].privateKey
+    )
+    const carolSyncLightClient = await createClientFromPrivateKey(
+      carolLightClient['wallet']['ethersWallet'].privateKey
+    )
+    await sleep(20000)
+    expect(await getBalance(aliceSyncLightClient)).toEqual('1.1')
+    expect(await getBalance(bobSyncLightClient)).toEqual('0.1')
+    expect(await getBalance(carolSyncLightClient)).toEqual('0.3')
+    aliceSyncLightClient.stop()
+    bobSyncLightClient.stop()
+    carolSyncLightClient.stop()
+
     const aliceActions = await aliceLightClient.getAllUserActions()
 
     expect(aliceActions.map(formatAction)).toEqual([

--- a/packages/contract/src/contract/interfaces/IDepositContract.ts
+++ b/packages/contract/src/contract/interfaces/IDepositContract.ts
@@ -48,7 +48,7 @@ export interface IDepositContract {
 
   subscribeDepositedRangeRemoved(handler: (range: Range) => Promise<void>): void
 
-  startWatchingEvents(): void
+  startWatchingEvents(): Promise<void>
 
   unsubscribeAll(): void
 }

--- a/packages/contract/src/contract/interfaces/IDepositContract.ts
+++ b/packages/contract/src/contract/interfaces/IDepositContract.ts
@@ -48,6 +48,9 @@ export interface IDepositContract {
 
   subscribeDepositedRangeRemoved(handler: (range: Range) => Promise<void>): void
 
+  /**
+   * startWatchingEvents wait until fetch latest events
+   */
   startWatchingEvents(): Promise<void>
 
   unsubscribeAll(): void

--- a/packages/plasma-light-client/src/LightClient.ts
+++ b/packages/plasma-light-client/src/LightClient.ts
@@ -409,7 +409,7 @@ export default class LightClient {
       this.handleCheckpointFinalized.bind(this)
     )
 
-    depositContract.startWatchingEvents()
+    await depositContract.startWatchingEvents()
   }
 
   // Exit Usecase

--- a/packages/plasma-light-client/src/LightClient.ts
+++ b/packages/plasma-light-client/src/LightClient.ts
@@ -409,6 +409,7 @@ export default class LightClient {
       this.handleCheckpointFinalized.bind(this)
     )
 
+    // wait until syncing checkpoints events
     await depositContract.startWatchingEvents()
   }
 

--- a/packages/plasma-light-client/src/usecase/StateSyncer.ts
+++ b/packages/plasma-light-client/src/usecase/StateSyncer.ts
@@ -206,20 +206,10 @@ export class StateSyncer {
   }
 
   public async syncRootUntil(blockNumber: BigNumber) {
-    const { coder } = ovmContext
     let synced = blockNumber
     while (JSBI.greaterThan(synced.data, JSBI.BigInt(0))) {
-      const storageDb = await getStorageDb(this.witnessDb)
-      const bucket = await storageDb.bucket(
-        coder.encode(this.commitmentVerifierAddress)
-      )
-      const encodedRoot = await bucket.get(coder.encode(blockNumber))
-      if (encodedRoot === null) {
-        const root = await this.commitmentContract.getRoot(blockNumber)
-        await this.storeRoot(blockNumber, root)
-      } else {
-        break
-      }
+      const root = await this.commitmentContract.getRoot(synced)
+      await this.storeRoot(synced, root)
       synced = BigNumber.from(JSBI.subtract(synced.data, JSBI.BigInt(1)))
     }
   }


### PR DESCRIPTION
fix the bug that client can't sync state correctly because of 2 reasons.

* StateSyncer didn't sync Merge Root correctly
* Client sometimes sync checkpoint after syncLatest
